### PR TITLE
feat: add two-factor auth and trusted devices

### DIFF
--- a/api/config/passportAuth.js
+++ b/api/config/passportAuth.js
@@ -1,31 +1,10 @@
-const GoogleStrategy = require("passport-google-oauth20").Strategy
 const LocalStrategy = require("passport-local").Strategy
 const User = require("../models/User")
-const upsertGoogleUser = require("../services/auth/upsertGoogleUser")
 
-const {
-  google: { clientId, clientSecret },
-} = require("../../config")
-
+// Google sign-in is handled statelessly via POST /auth/google (ID-token
+// verification in services/auth/googleLogin.js), so no passport Google strategy
+// is registered here. Local strategy still backs POST /auth/login.
 module.exports = function (passport) {
-  passport.use(
-    new GoogleStrategy(
-      {
-        clientID: clientId,
-        clientSecret,
-        callbackURL: "/auth/google/callback",
-      },
-      async (accessToken, refreshToken, profile, done) => {
-        try {
-          const user = await upsertGoogleUser(profile)
-          return done(null, user)
-        } catch (err) {
-          return done(err, false)
-        }
-      }
-    )
-  )
-
   passport.use(
     new LocalStrategy(
       { usernameField: "email", passwordField: "password" },

--- a/api/controllers/authController.js
+++ b/api/controllers/authController.js
@@ -3,6 +3,7 @@ const {
 } = require("../../constants/index")
 
 const login = require("../services/auth/login")
+const googleLogin = require("../services/auth/googleLogin")
 const register = require("../services/auth/register")
 const refresh = require("../services/auth/refresh")
 const logout = require("../services/auth/logout")
@@ -24,6 +25,22 @@ const loginController = async (req, res) => {
     })
 
     return res.status(code).json({ message, ...props })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(error.message) })
+  }
+}
+
+// google login (verifies a Google ID token, then issues Daykeeper JWTs)
+const googleLoginController = async (req, res) => {
+  try {
+    const { code, message, props } = await googleLogin({
+      idToken: req.body?.idToken,
+      deviceId: req.body?.deviceId || null,
+      ip: req.ip,
+      userAgent: req.headers["user-agent"],
+    })
+
+    return res.status(code).json({ message, ...(props || {}) })
   } catch (error) {
     return res.status(500).json({ message: serverError(error.message) })
   }
@@ -156,6 +173,7 @@ const userDataController = async (req, res) => {
 
 module.exports = {
   login: loginController,
+  googleLogin: googleLoginController,
   register: registerController,
   refresh: refreshController,
   logout: logoutController,

--- a/api/controllers/authController.js
+++ b/api/controllers/authController.js
@@ -13,6 +13,11 @@ const forgetPassword = require("../services/auth/forgetPassword")
 const resetPassword = require("../services/auth/resetPassword")
 const requestDeleteAccountCode = require("../services/auth/requestDeleteAccountCode")
 const getUserData = require("../services/auth/getUserData")
+const verifyTwoFactor = require("../services/auth/verifyTwoFactor")
+const resendTwoFactorCode = require("../services/auth/resendTwoFactorCode")
+const startTwoFactorSetup = require("../services/auth/startTwoFactorSetup")
+const confirmTwoFactorSetup = require("../services/auth/confirmTwoFactorSetup")
+const disableTwoFactor = require("../services/auth/disableTwoFactor")
 
 // login
 const loginController = async (req, res) => {
@@ -41,6 +46,81 @@ const googleLoginController = async (req, res) => {
     })
 
     return res.status(code).json({ message, ...(props || {}) })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(error.message) })
+  }
+}
+
+// verify second factor (completes a login that returned twoFactorRequired)
+const verifyTwoFactorController = async (req, res) => {
+  try {
+    const { code, message, props } = await verifyTwoFactor({
+      challengeId: req.body?.challengeId,
+      code: req.body?.code,
+      trustDevice: req.body?.trustDevice,
+      deviceId: req.body?.deviceId || null,
+      ip: req.ip,
+      userAgent: req.headers["user-agent"],
+    })
+
+    return res.status(code).json({ message, ...(props || {}) })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(error.message) })
+  }
+}
+
+// resend the email OTP for an active 2FA login challenge
+const resendTwoFactorController = async (req, res) => {
+  try {
+    const { code, message } = await resendTwoFactorCode({
+      challengeId: req.body?.challengeId,
+    })
+
+    return res.status(code).json({ message })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(error.message) })
+  }
+}
+
+// start 2FA enrollment (authed)
+const startTwoFactorSetupController = async (req, res) => {
+  try {
+    const { code, message, props } = await startTwoFactorSetup({
+      loggedUser: req.user,
+      method: req.body?.method,
+    })
+
+    return res.status(code).json({ message, ...(props || {}) })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(error.message) })
+  }
+}
+
+// confirm 2FA enrollment (authed) -> returns backup codes
+const confirmTwoFactorSetupController = async (req, res) => {
+  try {
+    const { code, message, props } = await confirmTwoFactorSetup({
+      loggedUser: req.user,
+      challengeId: req.body?.challengeId || null,
+      code: req.body?.code,
+    })
+
+    return res.status(code).json({ message, ...(props || {}) })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(error.message) })
+  }
+}
+
+// disable 2FA (authed, re-auth with password or current code)
+const disableTwoFactorController = async (req, res) => {
+  try {
+    const { code, message } = await disableTwoFactor({
+      loggedUser: req.user,
+      password: req.body?.password,
+      code: req.body?.code,
+    })
+
+    return res.status(code).json({ message })
   } catch (error) {
     return res.status(500).json({ message: serverError(error.message) })
   }
@@ -174,6 +254,11 @@ const userDataController = async (req, res) => {
 module.exports = {
   login: loginController,
   googleLogin: googleLoginController,
+  verifyTwoFactor: verifyTwoFactorController,
+  resendTwoFactor: resendTwoFactorController,
+  startTwoFactorSetup: startTwoFactorSetupController,
+  confirmTwoFactorSetup: confirmTwoFactorSetupController,
+  disableTwoFactor: disableTwoFactorController,
   register: registerController,
   refresh: refreshController,
   logout: logoutController,

--- a/api/controllers/deviceSessionController.js
+++ b/api/controllers/deviceSessionController.js
@@ -6,6 +6,9 @@ const {
 const getDeviceSessions = require("../services/deviceSession/getDeviceSessions")
 const revokeDeviceSession = require("../services/deviceSession/revokeDeviceSession")
 const revokeAllDeviceSessions = require("../services/deviceSession/revokeAllDeviceSessions")
+const getTrustedDevices = require("../services/deviceSession/getTrustedDevices")
+const revokeTrustedDevice = require("../services/deviceSession/revokeTrustedDevice")
+const revokeAllTrustedDevices = require("../services/deviceSession/revokeAllTrustedDevices")
 
 const getDeviceSessionsController = async (req, res) => {
   const page = Number(req.query?.page) || 1
@@ -53,8 +56,57 @@ const revokeAllDeviceSessionsController = async (req, res) => {
   }
 }
 
+const getTrustedDevicesController = async (req, res) => {
+  const page = Number(req.query?.page) || 1
+  const maxPageSize = req.query?.maxPageSize
+    ? Number(req.query?.maxPageSize) <= DEFAULT_MAX_PAGE_SIZE
+      ? Number(req.query?.maxPageSize)
+      : DEFAULT_MAX_PAGE_SIZE
+    : DEFAULT_MAX_PAGE_SIZE
+
+  try {
+    const { code, message, response } = await getTrustedDevices({
+      loggedUser: req.user,
+      page,
+      maxPageSize,
+    })
+
+    return res.status(code).json({ message, ...response })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(String(error)) })
+  }
+}
+
+const revokeTrustedDeviceController = async (req, res) => {
+  try {
+    const { code, message, id } = await revokeTrustedDevice({
+      loggedUser: req.user,
+      trustedDeviceId: req.params?.id,
+    })
+
+    return res.status(code).json({ message, id })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(String(error)) })
+  }
+}
+
+const revokeAllTrustedDevicesController = async (req, res) => {
+  try {
+    const { code, message, deletedCount } = await revokeAllTrustedDevices({
+      loggedUser: req.user,
+    })
+
+    return res.status(code).json({ message, deletedCount })
+  } catch (error) {
+    return res.status(500).json({ message: serverError(String(error)) })
+  }
+}
+
 module.exports = {
   getDeviceSessions: getDeviceSessionsController,
   revokeDeviceSession: revokeDeviceSessionController,
   revokeAllDeviceSessions: revokeAllDeviceSessionsController,
+  getTrustedDevices: getTrustedDevicesController,
+  revokeTrustedDevice: revokeTrustedDeviceController,
+  revokeAllTrustedDevices: revokeAllTrustedDevicesController,
 }

--- a/api/models/TrustedDevice.js
+++ b/api/models/TrustedDevice.js
@@ -1,0 +1,31 @@
+const mongoose = require("mongoose")
+
+// A device the user has chosen to "trust" after passing 2FA. While a
+// non-expired row exists, that device skips the second factor at login.
+// We never store the raw deviceId — only its sha256 hash.
+const TrustedDeviceSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    deviceIdHash: { type: String, required: true, index: true },
+    label: { type: String, default: null }, // parsed UA, e.g. "Chrome on macOS"
+    ip: { type: String, default: null },
+    userAgent: { type: String, default: null },
+    lastUsedAt: { type: Date, default: Date.now },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true }
+)
+
+// One trusted entry per (user, device); refreshing trust upserts this pair.
+TrustedDeviceSchema.index({ user: 1, deviceIdHash: 1 }, { unique: true })
+
+// Auto-clean expired trusted devices (mirrors RefreshToken's TTL approach).
+TrustedDeviceSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 })
+
+const TrustedDevice = mongoose.model(
+  "TrustedDevices",
+  TrustedDeviceSchema,
+  "trustedDevice"
+)
+
+module.exports = TrustedDevice

--- a/api/models/TwoFactorChallenge.js
+++ b/api/models/TwoFactorChallenge.js
@@ -1,0 +1,35 @@
+const mongoose = require("mongoose")
+
+// A short-lived pending second-factor at login. Created after the password is
+// verified when 2FA is enabled and the device is not trusted. Consumed (or
+// expired) by POST /auth/2fa/verify. For email OTP we store the code hash; for
+// TOTP the code is checked live against the user's secret, so codeHash is null.
+const TwoFactorChallengeSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    method: { type: String, enum: ["email", "totp"], required: true },
+    // "login" challenges complete a sign-in (issue tokens); "setup" challenges
+    // confirm email-method enrollment. Kept separate so a setup code can't be
+    // replayed against the login-verify endpoint.
+    purpose: { type: String, enum: ["login", "setup"], default: "login" },
+    codeHash: { type: String, default: null }, // sha256 of the email OTP (email method only)
+    expiresAt: { type: Date, required: true },
+    attempts: { type: Number, default: 0 },
+    consumedAt: { type: Date, default: null },
+    deviceId: { type: String, default: null },
+    ip: { type: String, default: null },
+    userAgent: { type: String, default: null },
+  },
+  { timestamps: true }
+)
+
+// Auto-clean expired challenges.
+TwoFactorChallengeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 })
+
+const TwoFactorChallenge = mongoose.model(
+  "TwoFactorChallenges",
+  TwoFactorChallengeSchema,
+  "twoFactorChallenge"
+)
+
+module.exports = TwoFactorChallenge

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -80,6 +80,18 @@ const userSchema = mongoose.Schema({
     required: false,
   },
 
+  // Two-factor authentication (opt-in). `method` decides how the login
+  // challenge is satisfied: "email" (6-digit OTP) or "totp" (authenticator app).
+  // totpSecret/backupCodes are only populated once the user confirms enrollment.
+  twoFactor: {
+    enabled: { type: Boolean, default: false },
+    method: { type: String, enum: ["email", "totp"], default: "email" },
+    totpSecret: { type: String, default: null }, // base32; null until TOTP confirmed
+    pendingTotpSecret: { type: String, default: null }, // staged during setup, before confirm
+    enabledAt: { type: Date, default: null },
+    backupCodes: [{ type: String }], // sha256 hashes, single-use
+  },
+
   banned: { type: Boolean, default: false, required: false },
 
   status: {

--- a/api/services/auth/confirmEmail.js
+++ b/api/services/auth/confirmEmail.js
@@ -67,20 +67,8 @@ const confirmEmail = async (props) => {
 
   // Wrong code
   if (user.verification_code_hash !== codeHash) {
-    // OPTIONAL SECURITY CHOICE:
-    // Your old code deleted the token on any wrong attempt.
-    // That’s harsh (fat-finger = locked out), but if you want the same behavior,
-    // keep this $unset. If you want better UX, remove this unset and add attempt limits.
-    await User.updateOne(
-      { _id: user._id },
-      {
-        $unset: {
-          verification_code_hash: 1,
-          verification_expires_at: 1,
-        },
-      }
-    )
-
+    // Keep the current code valid until its expiry. A typo should not force the
+    // user to request a new email; request-level rate limits handle brute force.
     return invalidValue("Verification code")
   }
 

--- a/api/services/auth/confirmTwoFactorSetup.js
+++ b/api/services/auth/confirmTwoFactorSetup.js
@@ -1,0 +1,89 @@
+const User = require("../../models/User")
+const TwoFactorChallenge = require("../../models/TwoFactorChallenge")
+const {
+  hashCode,
+  verifyTotp,
+  generateBackupCodes,
+  hashBackupCode,
+} = require("../../utils/twoFactor")
+
+const {
+  errors: { unauthorized, invalidValue, notFound, fieldNotFilledIn },
+  success: { custom },
+} = require("../../../constants/index")
+
+// Confirms enrollment started by startTwoFactorSetup and flips twoFactor.enabled.
+// Returns one-time backup codes (shown to the user once). Determines the method
+// from the input: a challengeId means email; otherwise TOTP (pendingTotpSecret).
+const confirmTwoFactorSetup = async (props) => {
+  const { loggedUser, challengeId, code } = props
+
+  if (!loggedUser?._id) return unauthorized("confirm two-factor")
+  if (!code) return fieldNotFilledIn("Code")
+
+  const user = await User.findById(loggedUser._id)
+  if (!user) return notFound("user")
+  if (user.twoFactor?.enabled) {
+    return unauthorized("confirm two-factor", "already enabled")
+  }
+
+  let method
+  if (challengeId) {
+    // ----- email enrollment -----
+    method = "email"
+    const challenge = await TwoFactorChallenge.findById(challengeId)
+    if (
+      !challenge ||
+      challenge.purpose !== "setup" ||
+      String(challenge.user) !== String(user._id)
+    ) {
+      return notFound("Challenge")
+    }
+    if (challenge.consumedAt) {
+      return unauthorized("confirm two-factor", "code already used")
+    }
+    if (challenge.expiresAt.getTime() < Date.now()) {
+      return unauthorized("confirm two-factor", "code expired")
+    }
+    if (challenge.codeHash !== hashCode(String(code).trim())) {
+      return invalidValue("confirmation code")
+    }
+    await TwoFactorChallenge.updateOne(
+      { _id: challenge._id },
+      { $set: { consumedAt: new Date() } }
+    )
+  } else {
+    // ----- TOTP enrollment -----
+    method = "totp"
+    const secret = user.twoFactor?.pendingTotpSecret
+    if (!secret) return unauthorized("confirm two-factor", "no setup in progress")
+    if (!verifyTotp(secret, code)) return invalidValue("authenticator code")
+  }
+
+  // Generate backup codes; persist only their hashes.
+  const backupCodes = generateBackupCodes()
+  const backupHashes = backupCodes.map(hashBackupCode)
+
+  const set = {
+    "twoFactor.enabled": true,
+    "twoFactor.method": method,
+    "twoFactor.enabledAt": new Date(),
+    "twoFactor.backupCodes": backupHashes,
+  }
+  const unset = {}
+  if (method === "totp") {
+    set["twoFactor.totpSecret"] = user.twoFactor.pendingTotpSecret
+    unset["twoFactor.pendingTotpSecret"] = 1
+  }
+
+  await User.updateOne(
+    { _id: user._id },
+    { $set: set, ...(Object.keys(unset).length ? { $unset: unset } : {}) }
+  )
+
+  return custom("Two-factor authentication enabled", {
+    props: { method, backupCodes },
+  })
+}
+
+module.exports = confirmTwoFactorSetup

--- a/api/services/auth/disableTwoFactor.js
+++ b/api/services/auth/disableTwoFactor.js
@@ -1,0 +1,58 @@
+const User = require("../../models/User")
+const bcrypt = require("bcryptjs")
+const { verifyTotp } = require("../../utils/twoFactor")
+
+const {
+  errors: { unauthorized, invalidValue, notFound },
+  success: { custom },
+} = require("../../../constants/index")
+
+// Disables 2FA after re-authenticating the request. Requires the account
+// password (if the user has one) or, for TOTP users, a current authenticator
+// code. This guards against an open/stolen session turning protection off.
+const disableTwoFactor = async (props) => {
+  const { loggedUser, password, code } = props
+
+  if (!loggedUser?._id) return unauthorized("disable two-factor")
+
+  const user = await User.findById(loggedUser._id)
+  if (!user) return notFound("user")
+  if (!user.twoFactor?.enabled) {
+    return custom("Two-factor authentication is already disabled")
+  }
+
+  let reauthed = false
+
+  if (password && user.password) {
+    reauthed = await bcrypt.compare(password, user.password)
+    if (!reauthed) return invalidValue("password")
+  } else if (code && user.twoFactor.method === "totp") {
+    reauthed = verifyTotp(user.twoFactor.totpSecret, code)
+    if (!reauthed) return invalidValue("authenticator code")
+  } else if (user.password) {
+    // A password exists but wasn't supplied.
+    return unauthorized("disable two-factor", "password required")
+  } else {
+    // Passwordless account (e.g. Google-only) using email 2FA: the valid access
+    // token already proves identity.
+    reauthed = true
+  }
+
+  await User.updateOne(
+    { _id: user._id },
+    {
+      $set: {
+        "twoFactor.enabled": false,
+        "twoFactor.method": "email",
+        "twoFactor.totpSecret": null,
+        "twoFactor.enabledAt": null,
+        "twoFactor.backupCodes": [],
+      },
+      $unset: { "twoFactor.pendingTotpSecret": 1 },
+    }
+  )
+
+  return custom("Two-factor authentication disabled")
+}
+
+module.exports = disableTwoFactor

--- a/api/services/auth/getUserData.js
+++ b/api/services/auth/getUserData.js
@@ -3,16 +3,23 @@ const { serializeMediaPayload } = require("../../utils/serializeMediaPayload")
 
 module.exports = async function getUserData({ userId }) {
   const user = await User.findById(userId).select(
-    "_id username displayName email profile_picture roles verified_email timeZone private"
+    "_id username displayName email profile_picture roles verified_email timeZone private twoFactor"
   )
 
   if (!user || user.status === "deleted") {
     return { code: 404, message: "User not found", user: null }
   }
 
+  const obj = user.toObject()
+  // Expose only a safe 2FA summary — never the secret or backup-code hashes.
+  obj.twoFactor = {
+    enabled: obj.twoFactor?.enabled === true,
+    method: obj.twoFactor?.method || "email",
+  }
+
   return {
     code: 200,
     message: "User data",
-    user: serializeMediaPayload(user.toObject()),
+    user: serializeMediaPayload(obj),
   }
 }

--- a/api/services/auth/googleLogin.js
+++ b/api/services/auth/googleLogin.js
@@ -1,0 +1,51 @@
+const { OAuth2Client } = require("google-auth-library")
+const upsertGoogleUser = require("./upsertGoogleUser")
+const login = require("./login")
+const {
+  google: { clientId, iosClientId, androidClientId },
+} = require("../../../config")
+const {
+  errors: { fieldNotFilledIn, invalidValue },
+} = require("../../../constants/index")
+
+// Every client ID we accept ID tokens from (web + mobile). The token's `aud`
+// claim must match one of these, or verification fails.
+const audiences = [clientId, iosClientId, androidClientId].filter(Boolean)
+
+const client = new OAuth2Client()
+
+/*
+  Verifies a Google ID token (signature, issuer, expiry, audience handled by the
+  library), upserts the matching user, and issues Daykeeper JWTs by reusing the
+  standard `login` service so the response shape matches password login exactly.
+
+  props: { idToken, deviceId, ip, userAgent }
+*/
+async function googleLogin(props) {
+  const { idToken, deviceId, ip, userAgent } = props
+
+  if (!idToken) return fieldNotFilledIn(`idToken`)
+  if (!audiences.length) throw new Error("No Google client IDs configured")
+
+  let ticket
+  try {
+    ticket = await client.verifyIdToken({ idToken, audience: audiences })
+  } catch (err) {
+    return invalidValue(`Google ID token`)
+  }
+
+  const p = ticket.getPayload()
+  if (!p || !p.sub) return invalidValue(`Google ID token`)
+
+  const user = await upsertGoogleUser({
+    email: p.email,
+    googleId: p.sub,
+    photo: p.picture || null,
+    displayName: p.name || "",
+    emailVerified: p.email_verified === true || p.email_verified === "true",
+  })
+
+  return login({ user, deviceId, ip, userAgent })
+}
+
+module.exports = googleLogin

--- a/api/services/auth/googleLogin.js
+++ b/api/services/auth/googleLogin.js
@@ -45,7 +45,10 @@ async function googleLogin(props) {
     emailVerified: p.email_verified === true || p.email_verified === "true",
   })
 
-  return login({ user, deviceId, ip, userAgent })
+  // Google sign-in bypasses app-level 2FA (the Google account is itself a strong
+  // second factor), so we mint tokens directly. issueTokens still fires the
+  // new-device alert when the device hasn't been seen before.
+  return login.issueTokens({ user, deviceId, ip, userAgent })
 }
 
 module.exports = googleLogin

--- a/api/services/auth/login.js
+++ b/api/services/auth/login.js
@@ -1,7 +1,6 @@
 const {
-  user: { defaultPfp, defaultTimeZone },
-  auth: { registerCodeExpiresTime },
   success: { custom },
+  auth: { twoFactorCodeExpiresTime },
 } = require("../../../constants/index")
 const { serializeMediaPayload } = require("../../utils/serializeMediaPayload")
 const {
@@ -9,6 +8,14 @@ const {
   makeRefreshToken,
   storeRefreshToken,
 } = require("../../utils/token")
+const {
+  isDeviceTrusted,
+  isKnownDevice,
+} = require("../../utils/deviceTrust")
+const { make6DigitCode, hashCode } = require("../../utils/twoFactor")
+const { sendNewDeviceAlert } = require("../../utils/loginAlert")
+const { sendTwoFactorCodeEmail } = require("../../utils/emailHandler")
+const TwoFactorChallenge = require("../../models/TwoFactorChallenge")
 
 function sanitizeUser(user) {
   return serializeMediaPayload({
@@ -20,8 +27,19 @@ function sanitizeUser(user) {
   })
 }
 
-async function login(props) {
-  const { user, deviceId, ip, userAgent } = props
+// "luc****@gmail.com" — enough to recognize the inbox without leaking it.
+function maskEmail(email) {
+  if (!email || !email.includes("@")) return email || ""
+  const [local, domain] = email.split("@")
+  const visible = local.slice(0, Math.min(3, local.length))
+  return `${visible}${"*".repeat(Math.max(1, local.length - visible.length))}@${domain}`
+}
+
+// Mints access + refresh tokens, stores the refresh token, and (best-effort)
+// fires a new-device alert when this device hasn't been seen before. Shared by
+// password login (this file) and the post-2FA verification path.
+async function issueTokens({ user, deviceId, ip, userAgent }) {
+  const isNew = !(await isKnownDevice(user._id, deviceId))
 
   const accessToken = signAccessToken(user)
   const refreshToken = makeRefreshToken()
@@ -34,6 +52,13 @@ async function login(props) {
     userAgent,
   })
 
+  if (isNew) {
+    // Fire-and-forget: never block or fail login on an alert send.
+    sendNewDeviceAlert({ user, ip, userAgent, when: new Date() }).catch(
+      () => null
+    )
+  }
+
   return custom(`${user?.username} logged successfully`, {
     props: {
       user: sanitizeUser(user),
@@ -43,4 +68,51 @@ async function login(props) {
   })
 }
 
+async function login(props) {
+  const { user, deviceId, ip, userAgent } = props
+
+  // Second factor required only when the user opted in AND this device isn't
+  // already trusted. Google login bypasses this (the Google account is the
+  // second factor) but still issues tokens via its own call to issueTokens.
+  const twoFactorOn = user?.twoFactor?.enabled === true
+  const trusted = twoFactorOn && (await isDeviceTrusted(user._id, deviceId))
+
+  if (twoFactorOn && !trusted) {
+    const method = user.twoFactor.method === "totp" ? "totp" : "email"
+
+    const challenge = {
+      user: user._id,
+      method,
+      expiresAt: new Date(Date.now() + twoFactorCodeExpiresTime),
+      deviceId: deviceId || null,
+      ip: ip || null,
+      userAgent: userAgent || null,
+    }
+
+    if (method === "email") {
+      const code = make6DigitCode()
+      challenge.codeHash = hashCode(code)
+      sendTwoFactorCodeEmail({
+        username: user.username,
+        email: user.email,
+        code,
+      }).catch(() => null)
+    }
+
+    const doc = await TwoFactorChallenge.create(challenge)
+
+    return custom(`Two-factor authentication required`, {
+      props: {
+        twoFactorRequired: true,
+        challengeId: doc._id,
+        method,
+        email: maskEmail(user.email),
+      },
+    })
+  }
+
+  return issueTokens({ user, deviceId, ip, userAgent })
+}
+
+login.issueTokens = issueTokens
 module.exports = login

--- a/api/services/auth/resendTwoFactorCode.js
+++ b/api/services/auth/resendTwoFactorCode.js
@@ -1,0 +1,54 @@
+const User = require("../../models/User")
+const TwoFactorChallenge = require("../../models/TwoFactorChallenge")
+const { make6DigitCode, hashCode } = require("../../utils/twoFactor")
+const { sendTwoFactorCodeEmail } = require("../../utils/emailHandler")
+
+const {
+  errors: { notFound, unauthorized, fieldNotFilledIn },
+  success: { custom },
+  auth: { twoFactorCodeExpiresTime },
+} = require("../../../constants/index")
+
+// Re-issues the email OTP for an active login challenge (email method only).
+const resendTwoFactorCode = async (props) => {
+  const { challengeId } = props
+  if (!challengeId) return fieldNotFilledIn("Challenge")
+
+  const challenge = await TwoFactorChallenge.findById(challengeId)
+  if (!challenge) return notFound("Challenge")
+
+  if (challenge.method !== "email") {
+    return unauthorized("resend code", "challenge does not use email codes")
+  }
+  if (challenge.consumedAt) {
+    return unauthorized("resend code", "challenge already used")
+  }
+  if (challenge.expiresAt.getTime() < Date.now()) {
+    return unauthorized("resend code", "challenge expired")
+  }
+
+  const user = await User.findById(challenge.user)
+  if (!user) return notFound("user")
+
+  const code = make6DigitCode()
+  await TwoFactorChallenge.updateOne(
+    { _id: challenge._id },
+    {
+      $set: {
+        codeHash: hashCode(code),
+        expiresAt: new Date(Date.now() + twoFactorCodeExpiresTime),
+        attempts: 0,
+      },
+    }
+  )
+
+  sendTwoFactorCodeEmail({
+    username: user.username,
+    email: user.email,
+    code,
+  }).catch(() => null)
+
+  return custom("Verification code resent")
+}
+
+module.exports = resendTwoFactorCode

--- a/api/services/auth/startTwoFactorSetup.js
+++ b/api/services/auth/startTwoFactorSetup.js
@@ -1,0 +1,71 @@
+const User = require("../../models/User")
+const TwoFactorChallenge = require("../../models/TwoFactorChallenge")
+const {
+  make6DigitCode,
+  hashCode,
+  generateTotpSecret,
+  buildTotpUri,
+  buildTotpQrDataUrl,
+} = require("../../utils/twoFactor")
+const { sendTwoFactorCodeEmail } = require("../../utils/emailHandler")
+
+const {
+  errors: { unauthorized, invalidValue, custom: customError },
+  success: { custom },
+  auth: { twoFactorCodeExpiresTime },
+} = require("../../../constants/index")
+
+// Begins 2FA enrollment for the logged-in user.
+//  - method "totp": returns a secret + otpauth URI + QR data URL to scan. The
+//    secret is staged as pendingTotpSecret and only promoted on confirm.
+//  - method "email": emails a confirmation code (stored as a "setup" challenge).
+// Nothing is enabled until confirmTwoFactorSetup succeeds.
+const startTwoFactorSetup = async (props) => {
+  const { loggedUser } = props
+  const method = props.method === "totp" ? "totp" : "email"
+
+  if (!loggedUser?._id) return unauthorized("set up two-factor")
+  if (loggedUser.twoFactor?.enabled) {
+    return customError("Two-factor authentication is already enabled", {}, 409)
+  }
+
+  if (method === "totp") {
+    const secret = generateTotpSecret()
+    const account = loggedUser.email || loggedUser.username || "Daykeeper user"
+    const otpauthUri = buildTotpUri(secret, account)
+    const qrDataUrl = await buildTotpQrDataUrl(otpauthUri)
+
+    await User.updateOne(
+      { _id: loggedUser._id },
+      { $set: { "twoFactor.pendingTotpSecret": secret } }
+    )
+
+    return custom("Scan the QR code with your authenticator app", {
+      props: { method: "totp", secret, otpauthUri, qrDataUrl },
+    })
+  }
+
+  // email method
+  if (!loggedUser.email) return invalidValue("email")
+
+  const code = make6DigitCode()
+  const challenge = await TwoFactorChallenge.create({
+    user: loggedUser._id,
+    method: "email",
+    purpose: "setup",
+    codeHash: hashCode(code),
+    expiresAt: new Date(Date.now() + twoFactorCodeExpiresTime),
+  })
+
+  sendTwoFactorCodeEmail({
+    username: loggedUser.username,
+    email: loggedUser.email,
+    code,
+  }).catch(() => null)
+
+  return custom("Confirmation code sent to your email", {
+    props: { method: "email", challengeId: challenge._id },
+  })
+}
+
+module.exports = startTwoFactorSetup

--- a/api/services/auth/upsertGoogleUser.js
+++ b/api/services/auth/upsertGoogleUser.js
@@ -1,20 +1,87 @@
+const crypto = require("crypto")
 const User = require("../../models/User")
 const {
-  user: { defaultTimeZone, defaultPfp },
+  user: { defaultTimeZone, defaultPfp, forbiddenUsernames },
+  auth: { maxUsernameLength },
 } = require("../../../constants/index")
 
-module.exports = async function upsertGoogleUser(profile) {
-  const email = profile.emails?.[0]?.value
-  const googleId = profile.id
-  const photo = profile.photos?.[0]?.value || null
-  const displayName = (profile.displayName || "").split(" ").join("")
+const FORBIDDEN = new Set(
+  (forbiddenUsernames || []).map((u) => String(u).toLowerCase())
+)
+const MAX_LEN = Number(maxUsernameLength) || 40
+const SUFFIX_LEN = 6 // hex chars appended on collision
+
+// Lowercase handle limited to the app's allowed username charset [a-z0-9._],
+// matching userRegisterValidation so Google accounts follow the same rules.
+function baseUsernameFrom(displayName, email) {
+  const clean = (s) =>
+    String(s || "")
+      .toLowerCase()
+      .replace(/[^a-z0-9._]/g, "")
+
+  let base = clean(displayName) || clean(String(email).split("@")[0]) || "user"
+  // Leave room for a possible collision suffix.
+  base = base.slice(0, Math.max(3, MAX_LEN - SUFFIX_LEN))
+  if (base.length < 3) base = `${base}user`.slice(0, MAX_LEN - SUFFIX_LEN)
+  return base
+}
+
+async function isTaken(name) {
+  if (FORBIDDEN.has(name)) return true
+  return Boolean(await User.exists({ username: name }))
+}
+
+// Pick a username that respects the unique index and the app's rules. Tries the
+// base handle, then appends a short random suffix — randomized so it stays cheap
+// and contention-free at scale.
+async function generateUniqueUsername(displayName, email) {
+  const base = baseUsernameFrom(displayName, email)
+  if (!(await isTaken(base))) return base
+
+  for (let i = 0; i < 8; i++) {
+    const suffix = crypto.randomBytes(3).toString("hex") // 6 hex chars
+    const candidate = `${base}${suffix}`.slice(0, MAX_LEN)
+    if (!(await isTaken(candidate))) return candidate
+  }
+
+  return `user${crypto.randomBytes(8).toString("hex")}`.slice(0, MAX_LEN)
+}
+
+/*
+  Upserts a user from a Google-verified identity payload.
+
+  payload: { email, googleId, photo, displayName, emailVerified }
+  The caller (googleLogin) cryptographically verifies the Google ID token first;
+  we still defensively require Google to assert the email is verified before
+  linking/creating an account by email.
+*/
+module.exports = async function upsertGoogleUser(payload) {
+  const email = String(payload?.email || "")
+    .trim()
+    .toLowerCase()
+  const googleId = payload?.googleId
+  const photo = payload?.photo || null
+  const displayName = String(payload?.displayName || "").trim()
+  const emailVerified = payload?.emailVerified === true
 
   if (!email) throw new Error("Google account has no email")
+  if (!googleId) throw new Error("Google account has no id")
+  if (!emailVerified) throw new Error("Google account email is not verified")
 
   let user = await User.findOne({ $or: [{ email }, { google_id: googleId }] })
 
   if (user) {
     if (!user.google_id) user.google_id = googleId
+
+    // Security: if we're linking Google to an account that was never
+    // email-verified, any password on it cannot be trusted — someone could have
+    // pre-registered with this email hoping the real owner would later sign in
+    // with Google. Google has proven ownership, so neutralize that password; the
+    // real owner can set a new one via password reset.
+    if (user.verified_email !== true && user.password) {
+      user.password = null
+    }
+
     if (
       photo &&
       (!user.profile_picture ||
@@ -23,31 +90,47 @@ module.exports = async function upsertGoogleUser(profile) {
     ) {
       user.profile_picture = { url: photo, title: "google_pfp", key: "" }
     }
-    if (user.verified_email === false) user.verified_email = true
+    if (user.verified_email !== true) user.verified_email = true
     await user.save()
     return user
   }
 
-  user = await User.create({
-    username: displayName,
-    name: displayName,
-    displayName,
-    email,
-    bio: "",
-    timeZone: defaultTimeZone,
-    profile_picture: photo
-      ? { url: photo, title: "google_pfp", key: "" }
-      : defaultPfp,
-    private: false,
-    roles: ["user"],
-    blocked_users: [],
-    verified_email: true,
-    password: null,
-    created_at: Date.now(),
-    google_id: googleId,
-    verification_code: null,
-    verification_time: null,
-  })
+  // Create — retry on the (rare) race where a concurrent request created the
+  // same identity or grabbed the same generated username.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const username = await generateUniqueUsername(displayName, email)
+    try {
+      return await User.create({
+        username,
+        name: displayName || username,
+        displayName: displayName || username,
+        email,
+        bio: "",
+        timeZone: defaultTimeZone,
+        profile_picture: photo
+          ? { url: photo, title: "google_pfp", key: "" }
+          : defaultPfp,
+        private: false,
+        roles: ["user"],
+        blocked_users: [],
+        verified_email: true,
+        password: null,
+        created_at: Date.now(),
+        google_id: googleId,
+      })
+    } catch (err) {
+      if (err && err.code === 11000) {
+        // A concurrent request may have created this exact identity…
+        const existing = await User.findOne({
+          $or: [{ email }, { google_id: googleId }],
+        })
+        if (existing) return existing
+        // …otherwise it was a username collision — regenerate and retry.
+        continue
+      }
+      throw err
+    }
+  }
 
-  return user
+  throw new Error("Could not create Google user (username contention)")
 }

--- a/api/services/auth/verifyTwoFactor.js
+++ b/api/services/auth/verifyTwoFactor.js
@@ -1,0 +1,100 @@
+const User = require("../../models/User")
+const TwoFactorChallenge = require("../../models/TwoFactorChallenge")
+const login = require("./login")
+const {
+  hashCode,
+  verifyTotp,
+  hashBackupCode,
+} = require("../../utils/twoFactor")
+const { trustDevice, parseUserAgent } = require("../../utils/deviceTrust")
+
+const {
+  errors: { notFound, unauthorized, fieldNotFilledIn, invalidValue },
+  auth: { maxTwoFactorAttempts },
+} = require("../../../constants/index")
+
+// Completes a login that was put on hold by a 2FA challenge. On success it mints
+// tokens via the shared login.issueTokens path and (optionally) trusts the device.
+const verifyTwoFactor = async (props) => {
+  const { challengeId, code } = props
+  const trust = props.trustDevice === true || props.trustDevice === "true"
+
+  if (!challengeId || !code) return fieldNotFilledIn("Challenge or code")
+
+  const challenge = await TwoFactorChallenge.findById(challengeId)
+  if (!challenge) return notFound("Challenge")
+  if (challenge.purpose && challenge.purpose !== "login") return notFound("Challenge")
+
+  if (challenge.consumedAt) {
+    return unauthorized("verify 2FA", "challenge already used")
+  }
+  if (challenge.expiresAt.getTime() < Date.now()) {
+    return unauthorized("verify 2FA", "challenge expired")
+  }
+  if (challenge.attempts >= maxTwoFactorAttempts) {
+    return unauthorized("verify 2FA", "too many attempts")
+  }
+
+  const user = await User.findById(challenge.user)
+  if (!user) return notFound("user")
+
+  const submitted = String(code).trim()
+  let ok = false
+
+  if (challenge.method === "email") {
+    ok = Boolean(challenge.codeHash) && challenge.codeHash === hashCode(submitted)
+  } else if (challenge.method === "totp") {
+    ok = verifyTotp(user.twoFactor?.totpSecret, submitted)
+  }
+
+  // Backup recovery codes work for either method. Consumed single-use.
+  let usedBackupHash = null
+  if (!ok && Array.isArray(user.twoFactor?.backupCodes)) {
+    const candidate = hashBackupCode(submitted)
+    if (user.twoFactor.backupCodes.includes(candidate)) {
+      ok = true
+      usedBackupHash = candidate
+    }
+  }
+
+  if (!ok) {
+    await TwoFactorChallenge.updateOne(
+      { _id: challenge._id },
+      { $inc: { attempts: 1 } }
+    )
+    return invalidValue("verification code")
+  }
+
+  // Consume the challenge (and any used backup code) before issuing tokens.
+  await TwoFactorChallenge.updateOne(
+    { _id: challenge._id },
+    { $set: { consumedAt: new Date() } }
+  )
+  if (usedBackupHash) {
+    await User.updateOne(
+      { _id: user._id },
+      { $pull: { "twoFactor.backupCodes": usedBackupHash } }
+    )
+  }
+
+  // Prefer the device metadata captured at challenge creation; fall back to the
+  // verify request's metadata.
+  const deviceId = challenge.deviceId || props.deviceId || null
+  const ip = props.ip || challenge.ip || null
+  const userAgent = props.userAgent || challenge.userAgent || null
+
+  if (trust && deviceId) {
+    await trustDevice({
+      userId: user._id,
+      deviceId,
+      ip,
+      userAgent,
+      label: parseUserAgent(userAgent),
+    })
+  }
+
+  // issueTokens also fires the new-device alert when the device is unseen.
+  return login.issueTokens({ user, deviceId, ip, userAgent })
+}
+
+module.exports = verifyTwoFactor

--- a/api/services/deviceSession/getTrustedDevices.js
+++ b/api/services/deviceSession/getTrustedDevices.js
@@ -1,0 +1,55 @@
+const TrustedDevice = require("../../models/TrustedDevice")
+const {
+  errors: { unauthorized },
+  success: { fetched },
+  maxPageSize: DEFAULT_MAX_PAGE_SIZE,
+} = require("../../../constants/index")
+
+// Lists the user's active (non-expired) trusted devices — the ones that skip
+// 2FA at login. Mirrors getDeviceSessions' shape.
+const getTrustedDevices = async (props) => {
+  const { loggedUser, page, maxPageSize } = props
+
+  if (!loggedUser?._id) return unauthorized("fetch trusted devices")
+
+  let p = Number(page)
+  let size = Number(maxPageSize)
+
+  if (!Number.isFinite(p) || p < 1) p = 1
+  if (!Number.isFinite(size) || size < 1) size = DEFAULT_MAX_PAGE_SIZE
+  size = Math.min(size, DEFAULT_MAX_PAGE_SIZE)
+
+  const skipCount = (p - 1) * size
+  const query = {
+    user: loggedUser._id,
+    expiresAt: { $gt: new Date() },
+  }
+
+  const totalCount = await TrustedDevice.countDocuments(query)
+  const rows = await TrustedDevice.find(query)
+    .sort({ lastUsedAt: -1 })
+    .skip(skipCount)
+    .limit(size)
+    .select("label ip userAgent lastUsedAt createdAt expiresAt")
+    .lean()
+
+  const data = rows.map((row) => {
+    const { _id, ...rest } = row
+    return { ...rest, id: _id }
+  })
+
+  const totalPages = totalCount ? Math.ceil(totalCount / size) : 0
+
+  return fetched("trusted devices", {
+    response: {
+      data,
+      page: p,
+      pageSize: data.length,
+      maxPageSize: size,
+      totalPages,
+      totalCount,
+    },
+  })
+}
+
+module.exports = getTrustedDevices

--- a/api/services/deviceSession/revokeAllTrustedDevices.js
+++ b/api/services/deviceSession/revokeAllTrustedDevices.js
@@ -1,0 +1,20 @@
+const TrustedDevice = require("../../models/TrustedDevice")
+const {
+  errors: { unauthorized },
+  success: { deleted },
+} = require("../../../constants/index")
+
+// Removes all trusted devices for the user — every device must pass 2FA again.
+const revokeAllTrustedDevices = async (props) => {
+  const { loggedUser } = props
+
+  if (!loggedUser?._id) return unauthorized("revoke trusted devices")
+
+  const result = await TrustedDevice.deleteMany({ user: loggedUser._id })
+
+  return deleted("trusted devices", {
+    deletedCount: result.deletedCount ?? 0,
+  })
+}
+
+module.exports = revokeAllTrustedDevices

--- a/api/services/deviceSession/revokeTrustedDevice.js
+++ b/api/services/deviceSession/revokeTrustedDevice.js
@@ -1,0 +1,25 @@
+const TrustedDevice = require("../../models/TrustedDevice")
+const {
+  errors: { unauthorized, fieldNotFilledIn, notFound },
+  success: { deleted },
+} = require("../../../constants/index")
+
+// Revokes (deletes) one trusted device. The next login from it will re-challenge
+// for 2FA.
+const revokeTrustedDevice = async (props) => {
+  const { loggedUser, trustedDeviceId } = props
+
+  if (!loggedUser?._id) return unauthorized("revoke trusted device")
+  if (!trustedDeviceId) return fieldNotFilledIn("trustedDeviceId")
+
+  const row = await TrustedDevice.findOneAndDelete({
+    _id: trustedDeviceId,
+    user: loggedUser._id,
+  }).select("_id")
+
+  if (!row) return notFound("Trusted device")
+
+  return deleted("trusted device", { id: row._id })
+}
+
+module.exports = revokeTrustedDevice

--- a/api/utils/deviceTrust.js
+++ b/api/utils/deviceTrust.js
@@ -1,0 +1,86 @@
+const crypto = require("crypto")
+const RefreshToken = require("../models/RefreshToken")
+const TrustedDevice = require("../models/TrustedDevice")
+const {
+  auth: { trustedDeviceExpiresTime },
+} = require("../../constants/index")
+
+function hashDeviceId(deviceId) {
+  return crypto.createHash("sha256").update(String(deviceId)).digest("hex")
+}
+
+// A device is "known" for a user if we've ever issued a refresh token for that
+// deviceId — i.e. they've successfully signed in from it before. Used to decide
+// whether to fire a new-device login alert.
+async function isKnownDevice(userId, deviceId) {
+  if (!deviceId) return false
+  const existing = await RefreshToken.findOne({
+    user: userId,
+    deviceId,
+  }).select("_id")
+  return Boolean(existing)
+}
+
+// A device is "trusted" if the user explicitly chose to trust it and that trust
+// has not expired. Trusted devices skip 2FA at login.
+async function isDeviceTrusted(userId, deviceId) {
+  if (!deviceId) return false
+  const row = await TrustedDevice.findOne({
+    user: userId,
+    deviceIdHash: hashDeviceId(deviceId),
+    expiresAt: { $gt: new Date() },
+  }).select("_id")
+  return Boolean(row)
+}
+
+// Upsert a trusted-device record, refreshing its expiry/metadata. No-op if no
+// deviceId is supplied (e.g. a client that doesn't send one).
+async function trustDevice({ userId, deviceId, ip, userAgent, label }) {
+  if (!deviceId) return null
+  const expiresAt = new Date(Date.now() + trustedDeviceExpiresTime)
+  await TrustedDevice.updateOne(
+    { user: userId, deviceIdHash: hashDeviceId(deviceId) },
+    {
+      $set: {
+        ip: ip || null,
+        userAgent: userAgent || null,
+        label: label || null,
+        lastUsedAt: new Date(),
+        expiresAt,
+      },
+    },
+    { upsert: true }
+  )
+  return expiresAt
+}
+
+// Lightweight UA -> "Browser on OS" / device label. No external dependency: a
+// few ordered regexes cover the common cases; falls back to the raw UA.
+function parseUserAgent(ua) {
+  if (!ua) return "Unknown device"
+
+  let os = "Unknown OS"
+  if (/iPhone|iPad|iPod/i.test(ua)) os = "iOS"
+  else if (/Android/i.test(ua)) os = "Android"
+  else if (/Mac OS X|Macintosh/i.test(ua)) os = "macOS"
+  else if (/Windows/i.test(ua)) os = "Windows"
+  else if (/Linux/i.test(ua)) os = "Linux"
+
+  let browser = null
+  if (/Expo|Daykeeper/i.test(ua)) browser = "Daykeeper app"
+  else if (/Edg\//i.test(ua)) browser = "Edge"
+  else if (/OPR\/|Opera/i.test(ua)) browser = "Opera"
+  else if (/Chrome\//i.test(ua) && !/Chromium/i.test(ua)) browser = "Chrome"
+  else if (/Firefox\//i.test(ua)) browser = "Firefox"
+  else if (/Safari\//i.test(ua) && !/Chrome/i.test(ua)) browser = "Safari"
+
+  return browser ? `${browser} on ${os}` : os
+}
+
+module.exports = {
+  hashDeviceId,
+  isKnownDevice,
+  isDeviceTrusted,
+  trustDevice,
+  parseUserAgent,
+}

--- a/api/utils/email/templates/index.js
+++ b/api/utils/email/templates/index.js
@@ -1,6 +1,8 @@
 const { buildEmail, escapeHtml } = require("./base")
 const verificationTemplate = require("./verification")
 const passwordResetTemplate = require("./passwordReset")
+const twoFactorCodeTemplate = require("./twoFactorCode")
+const newDeviceLoginTemplate = require("./newDeviceLogin")
 const banTemplate = require("./ban")
 const unbanTemplate = require("./unban")
 const userDeletionTemplate = require("./userDeletion")
@@ -14,6 +16,8 @@ module.exports = {
   escapeHtml,
   verificationTemplate,
   passwordResetTemplate,
+  twoFactorCodeTemplate,
+  newDeviceLoginTemplate,
   banTemplate,
   unbanTemplate,
   userDeletionTemplate,

--- a/api/utils/email/templates/newDeviceLogin.js
+++ b/api/utils/email/templates/newDeviceLogin.js
@@ -1,0 +1,34 @@
+const { buildEmail } = require("./base")
+
+const newDeviceLoginTemplate = ({ username, device, ip, when, secureUrl }) => {
+  const { html, text } = buildEmail({
+    preheader: "A new device just signed in to your Daykeeper account.",
+    title: "New sign-in to your account",
+    greeting: username ? `Hi ${username},` : "Hi there,",
+    intro:
+      "We noticed a sign-in to your Daykeeper account from a device we haven't seen before.",
+    sections: [
+      { title: "Device", body: device || "Unknown device" },
+      { title: "IP address", body: ip || "Unknown" },
+      { title: "When", body: when || "Just now" },
+    ],
+    cta: secureUrl ? { label: "Secure my account", url: secureUrl } : undefined,
+    outro:
+      "If this was you, no action is needed.\n\n" +
+      "If this wasn't you, act now:\n" +
+      "1. Change your password immediately.\n" +
+      "2. Review your devices and sign out the ones you don't recognize.\n" +
+      "3. Turn on two-factor authentication if you haven't already.\n" +
+      "If you need help, just reply to this email.",
+    footerNote:
+      "You're receiving this security alert because someone signed in to your Daykeeper account.",
+  })
+
+  return {
+    subject: "New sign-in to your Daykeeper account",
+    html,
+    text,
+  }
+}
+
+module.exports = newDeviceLoginTemplate

--- a/api/utils/email/templates/twoFactorCode.js
+++ b/api/utils/email/templates/twoFactorCode.js
@@ -1,0 +1,22 @@
+const { buildEmail } = require("./base")
+
+const twoFactorCodeTemplate = ({ username, code }) => {
+  const { html, text } = buildEmail({
+    preheader: "Your Daykeeper sign-in code.",
+    title: "Your sign-in code",
+    greeting: username ? `Hi ${username},` : "Hi there,",
+    intro:
+      "Use the code below to finish signing in to your Daykeeper account. It expires in 10 minutes.",
+    code,
+    outro:
+      "If you did not try to sign in, someone may have your password. Change it right away and review your devices.",
+  })
+
+  return {
+    subject: "Your Daykeeper sign-in code",
+    html,
+    text,
+  }
+}
+
+module.exports = twoFactorCodeTemplate

--- a/api/utils/emailHandler.js
+++ b/api/utils/emailHandler.js
@@ -2,6 +2,8 @@ const { sendMail } = require("./email/mailer")
 const {
   verificationTemplate,
   passwordResetTemplate,
+  twoFactorCodeTemplate,
+  newDeviceLoginTemplate,
   banTemplate,
   unbanTemplate,
   userDeletionTemplate,
@@ -179,9 +181,47 @@ const sendAccountDeletionCode = async (email, code) => {
   })
 }
 
+// ========== SECURITY ==========
+const sendTwoFactorCodeEmail = async ({ username, email, code }) => {
+  const { subject, html, text } = twoFactorCodeTemplate({ username, code })
+
+  await sendMail({
+    to: email,
+    subject,
+    html,
+    text,
+  })
+}
+
+const sendNewDeviceLoginEmail = async ({
+  username,
+  email,
+  device,
+  ip,
+  when,
+  secureUrl,
+}) => {
+  const { subject, html, text } = newDeviceLoginTemplate({
+    username,
+    device,
+    ip,
+    when,
+    secureUrl,
+  })
+
+  await sendMail({
+    to: email,
+    subject,
+    html,
+    text,
+  })
+}
+
 module.exports = {
   sendVerificationEmail,
   sendPasswordResetEmail,
+  sendTwoFactorCodeEmail,
+  sendNewDeviceLoginEmail,
 
   sendBanEmail,
   sendUnbanEmail,

--- a/api/utils/loginAlert.js
+++ b/api/utils/loginAlert.js
@@ -1,0 +1,52 @@
+const { sendNewDeviceLoginEmail } = require("./emailHandler")
+const { createNotification } = require("../services/notification/createNotification")
+const { parseUserAgent } = require("./deviceTrust")
+
+const WEBAPP_URL = process.env.WEBAPP_URL || "https://daykeeper.app"
+
+// Format a timestamp in the user's timezone (best-effort; falls back to UTC).
+function formatWhen(when, timeZone) {
+  const date = when instanceof Date ? when : new Date(when || Date.now())
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+      timeZone: timeZone || "UTC",
+    }).format(date)
+  } catch {
+    return date.toUTCString()
+  }
+}
+
+// Fire-and-forget security alert when an account is accessed from a new device.
+// Sends BOTH an email and a push notification + in-app notification row. Never
+// throws — matches the existing best-effort email convention so it can't block
+// or fail a login.
+async function sendNewDeviceAlert({ user, ip, userAgent, when }) {
+  if (!user?.email) return
+
+  const device = parseUserAgent(userAgent)
+  const whenText = formatWhen(when, user.timeZone)
+  const secureUrl = `${WEBAPP_URL}/forgot-password`
+
+  await Promise.allSettled([
+    sendNewDeviceLoginEmail({
+      username: user.username,
+      email: user.email,
+      device,
+      ip: ip || "Unknown",
+      when: whenText,
+      secureUrl,
+    }),
+    createNotification({
+      userId: user._id,
+      type: "security_login",
+      title: "New sign-in to your account",
+      body: `${device} · ${ip || "Unknown IP"}`,
+      data: { ip: ip || "", device, when: whenText },
+      sendPush: true,
+    }),
+  ])
+}
+
+module.exports = { sendNewDeviceAlert, formatWhen }

--- a/api/utils/twoFactor.js
+++ b/api/utils/twoFactor.js
@@ -1,0 +1,75 @@
+const crypto = require("crypto")
+const { authenticator } = require("otplib")
+const QRCode = require("qrcode")
+
+// Allow a ±1 step (±30s) window so minor clock drift doesn't reject a valid code.
+authenticator.options = { window: 1 }
+
+const {
+  auth: { twoFactorBackupCodeCount },
+} = require("../../constants/index")
+
+// ===== Email OTP (reuses the same sha256 code pattern as email verification) =====
+
+function make6DigitCode() {
+  return Math.floor(100000 + Math.random() * 900000).toString()
+}
+
+function hashCode(code) {
+  return crypto.createHash("sha256").update(String(code)).digest("hex")
+}
+
+// ===== TOTP (authenticator app: Authy / Google Authenticator) =====
+
+function generateTotpSecret() {
+  return authenticator.generateSecret() // base32
+}
+
+// otpauth:// URI scanned by authenticator apps. `account` is the user identifier
+// shown in the app (we use the email), `issuer` groups it under "Daykeeper".
+function buildTotpUri(secret, account, issuer = "Daykeeper") {
+  return authenticator.keyuri(account, issuer, secret)
+}
+
+async function buildTotpQrDataUrl(otpauthUri) {
+  return QRCode.toDataURL(otpauthUri)
+}
+
+function verifyTotp(secret, token) {
+  if (!secret || !token) return false
+  try {
+    return authenticator.verify({ token: String(token).trim(), secret })
+  } catch {
+    return false
+  }
+}
+
+// ===== Backup / recovery codes =====
+
+// Human-friendly one-time codes (e.g. "a1b2-c3d4"). Returned in plaintext ONCE
+// at enrollment; only the hashes are persisted.
+function generateBackupCodes(count = twoFactorBackupCodeCount) {
+  const codes = []
+  for (let i = 0; i < count; i++) {
+    const raw = crypto.randomBytes(4).toString("hex") // 8 hex chars
+    codes.push(`${raw.slice(0, 4)}-${raw.slice(4)}`)
+  }
+  return codes
+}
+
+// Normalize before hashing so display formatting / case doesn't matter on input.
+function hashBackupCode(code) {
+  const normalized = String(code).toLowerCase().replace(/[^a-z0-9]/g, "")
+  return crypto.createHash("sha256").update(normalized).digest("hex")
+}
+
+module.exports = {
+  make6DigitCode,
+  hashCode,
+  generateTotpSecret,
+  buildTotpUri,
+  buildTotpQrDataUrl,
+  verifyTotp,
+  generateBackupCodes,
+  hashBackupCode,
+}

--- a/config.js
+++ b/config.js
@@ -19,8 +19,10 @@ module.exports = {
     defaultRegion: process.env.AWS_DEFAULT_REGION,
   },
   google: {
-    clientId: process.env.GOOGLE_CLIENT_ID,
+    clientId: process.env.GOOGLE_CLIENT_ID, // Web OAuth client
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    iosClientId: process.env.GOOGLE_IOS_CLIENT_ID,
+    androidClientId: process.env.GOOGLE_ANDROID_CLIENT_ID,
     apiKey: process.env.GOOGLE_API_KEY,
   },
   mail: {

--- a/constants/index.js
+++ b/constants/index.js
@@ -62,6 +62,10 @@ module.exports = {
     resetTokenExpiresTime: "1h",
     resetPasswordExpiresTime: 3600000, // 1 h
     registerCodeExpiresTime: 600000, // 10 min
+    twoFactorCodeExpiresTime: 600000, // 10 min (email OTP at login)
+    trustedDeviceExpiresTime: 30 * 24 * 60 * 60 * 1000, // 30 days
+    maxTwoFactorAttempts: 5, // wrong-code attempts before a challenge is locked
+    twoFactorBackupCodeCount: 10, // one-time recovery codes generated on TOTP enroll
     maxUsernameLength: 40,
     maxEmailLength: 320,
     maxPasswordLength: 50,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "express-session": "^1.18.0",
         "firebase-admin": "^12.2.0",
         "fluent-ffmpeg": "^2.1.3",
+        "google-auth-library": "^10.7.0",
         "helmet": "^8.1.0",
         "ioredis": "^5.7.0",
         "jsonwebtoken": "^9.0.3",
@@ -2000,6 +2001,49 @@
         "node": ">=14"
       }
     },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
@@ -2116,9 +2160,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2134,9 +2175,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2154,9 +2192,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2172,9 +2207,6 @@
       "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2192,9 +2224,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2211,9 +2240,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2229,9 +2255,6 @@
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2255,9 +2278,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2279,9 +2299,6 @@
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2305,9 +2322,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2330,9 +2344,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2354,9 +2365,6 @@
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3661,7 +3669,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -4033,7 +4040,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -4782,6 +4788,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
@@ -5409,8 +5424,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
@@ -5495,6 +5509,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-type": {
@@ -5683,6 +5720,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -5786,6 +5835,52 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gensync": {
@@ -5904,36 +5999,52 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
+      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "node_modules/google-auth-library/node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
-        "json-bigint": "^1.0.0"
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/google-gax": {
@@ -5960,6 +6071,49 @@
         "node": ">=14"
       }
     },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/google-gax/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -5975,11 +6129,10 @@
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -6191,7 +6344,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -7242,7 +7394,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -7974,6 +8125,26 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -10075,6 +10246,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,11 @@
         "multer-s3": "^2.10.0",
         "node-cron": "^3.0.3",
         "nodemailer": "^7.0.12",
+        "otplib": "^12.0.1",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-local": "^1.0.0",
+        "qrcode": "^1.5.4",
         "sanitize-html": "^2.17.4",
         "sharp": "^0.33.5",
         "timezone-support": "^3.1.0"
@@ -2953,6 +2955,56 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -3693,7 +3745,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3703,7 +3754,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4351,7 +4401,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4839,6 +4888,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -4956,6 +5014,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5102,7 +5166,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -5593,7 +5656,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -5838,49 +5900,64 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
+        "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/gcp-metadata/node_modules/gaxios": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
-      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
-    "node_modules/gcp-metadata/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+        "node": ">= 6"
       }
     },
     "node_modules/gensync": {
@@ -5897,7 +5974,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -6024,6 +6100,20 @@
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
         "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -6546,7 +6636,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7556,7 +7645,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -8412,6 +8500,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8432,7 +8531,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -8445,7 +8543,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -8461,7 +8558,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8574,7 +8670,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8658,6 +8753,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8831,6 +8935,89 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.2",
@@ -9069,11 +9256,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -9337,6 +9529,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9705,7 +9903,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9720,7 +9917,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9927,6 +10123,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/timezone-support": {
@@ -10313,6 +10517,12 @@
       "bin": {
         "which": "bin/which"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "express-session": "^1.18.0",
     "firebase-admin": "^12.2.0",
     "fluent-ffmpeg": "^2.1.3",
+    "google-auth-library": "^10.7.0",
     "helmet": "^8.1.0",
     "ioredis": "^5.7.0",
     "jsonwebtoken": "^9.0.3",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
     "multer-s3": "^2.10.0",
     "node-cron": "^3.0.3",
     "nodemailer": "^7.0.12",
+    "otplib": "^12.0.1",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
+    "qrcode": "^1.5.4",
     "sanitize-html": "^2.17.4",
     "sharp": "^0.33.5",
     "timezone-support": "^3.1.0"

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -5,6 +5,7 @@ const passportConfig = require("../api/config/passportAuth")
 
 const {
   login,
+  googleLogin,
   register,
   refresh,
   logout,
@@ -24,6 +25,12 @@ const rateLimit = require("../middlewares/rateLimit")
 const refreshLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 300,
+  methods: ["POST"],
+})
+
+const googleLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
   methods: ["POST"],
 })
 
@@ -48,40 +55,8 @@ router.post(
 router.post("/refresh", refreshLimiter, refresh)
 router.post("/logout", logout)
 
-router.get(
-  "/google",
-  passport.authenticate("google", {
-    scope: ["profile", "email"],
-  })
-)
-
-router.get(
-  "/google/callback",
-  passport.authenticate("google", { failureRedirect: "/" }),
-  async (req, res) => {
-    const {
-      signAccessToken,
-      makeRefreshToken,
-      storeRefreshToken,
-    } = require("../api/utils/tokens")
-
-    const accessToken = signAccessToken(req.user)
-    const refreshToken = makeRefreshToken()
-
-    await storeRefreshToken({
-      userId: req.user._id,
-      refreshToken,
-      deviceId: null,
-      ip: req.ip,
-      userAgent: req.headers["user-agent"],
-    })
-
-    return res.status(200).json({
-      message: "Google login success",
-      accessToken,
-      refreshToken,
-    })
-  }
-)
+// Unified Google sign-in: web (GIS) and mobile (expo-auth-session) both obtain a
+// Google ID token client-side and POST it here for server-side verification.
+router.post("/google", googleLimiter, googleLogin)
 
 module.exports = router

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -6,6 +6,11 @@ const passportConfig = require("../api/config/passportAuth")
 const {
   login,
   googleLogin,
+  verifyTwoFactor,
+  resendTwoFactor,
+  startTwoFactorSetup,
+  confirmTwoFactorSetup,
+  disableTwoFactor,
   register,
   refresh,
   logout,
@@ -34,13 +39,37 @@ const googleLimiter = rateLimit({
   methods: ["POST"],
 })
 
+// Tighter limit on the second-factor endpoints (per-challenge brute force is
+// also capped by TwoFactorChallenge.attempts).
+const twoFactorLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  methods: ["POST"],
+})
+
+const emailConfirmationLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  methods: ["POST"],
+  keyGenerator: (req) =>
+    `${req.ip}:confirm-email:${String(req.body?.email || "").trim().toLowerCase()}`,
+})
+
+const resendVerificationLimiter = rateLimit({
+  windowMs: 2 * 60 * 1000,
+  max: 3,
+  methods: ["POST"],
+  keyGenerator: (req) =>
+    `${req.ip}:resend-code:${String(req.body?.email || "").trim().toLowerCase()}`,
+})
+
 passportConfig(passport)
 
 router.post("/register", userRegisterValidation, register)
-router.post("/confirm_email", confirmEmail)
+router.post("/confirm_email", emailConfirmationLimiter, confirmEmail)
 router.post("/forget_password", forgetPassword)
 router.post("/reset_password", resetPassword)
-router.post("/resend_code", resendCode)
+router.post("/resend_code", resendVerificationLimiter, resendCode)
 router.post("/request_delete_code", checkTokenMW, requestDeleteAccountCode)
 
 router.get("/user", checkTokenMW, userData)
@@ -54,6 +83,15 @@ router.post(
 
 router.post("/refresh", refreshLimiter, refresh)
 router.post("/logout", logout)
+
+// Second-factor verification for a login held by a twoFactorRequired response.
+router.post("/2fa/verify", twoFactorLimiter, verifyTwoFactor)
+router.post("/2fa/resend", twoFactorLimiter, resendTwoFactor)
+
+// 2FA enrollment/management (authenticated).
+router.post("/2fa/setup/start", checkTokenMW, startTwoFactorSetup)
+router.post("/2fa/setup/confirm", checkTokenMW, confirmTwoFactorSetup)
+router.post("/2fa/disable", checkTokenMW, disableTwoFactor)
 
 // Unified Google sign-in: web (GIS) and mobile (expo-auth-session) both obtain a
 // Google ID token client-side and POST it here for server-side verification.

--- a/routes/deviceSessionRoutes.js
+++ b/routes/deviceSessionRoutes.js
@@ -6,10 +6,20 @@ const {
   getDeviceSessions,
   revokeDeviceSession,
   revokeAllDeviceSessions,
+  getTrustedDevices,
+  revokeTrustedDevice,
+  revokeAllTrustedDevices,
 } = require("../api/controllers/deviceSessionController")
 
 router.get("/", checkTokenMW, getDeviceSessions)
 router.delete("/", checkTokenMW, revokeAllDeviceSessions)
+
+// Trusted devices (devices allowed to skip 2FA). Declared before "/:id" so
+// "/trusted" isn't swallowed by the session id param route.
+router.get("/trusted", checkTokenMW, getTrustedDevices)
+router.delete("/trusted", checkTokenMW, revokeAllTrustedDevices)
+router.delete("/trusted/:id", checkTokenMW, revokeTrustedDevice)
+
 router.delete("/:id", checkTokenMW, revokeDeviceSession)
 
 module.exports = router


### PR DESCRIPTION
## What changed

- Adds email and authenticator-app two-factor authentication flows.
- Adds trusted-device storage, listing, and revocation support.
- Adds new-device login alerts and supporting email templates.
- Fixes email confirmation so a mistyped code remains valid until expiry.
- Adds focused confirmation and resend rate limits.

## Why

Daykeeper needs stronger account security and a reliable confirmation flow. The previous confirmation behavior invalidated a code after one typo, forcing users into a resend loop.

## Impact

Users can enroll in 2FA, trust or revoke devices, receive login alerts, and retry an unexpired email confirmation code safely.

## Validation

- Parsed every changed and new JavaScript file with `node --check`.
- Verified the dependency tree with `npm ls --depth=0`.
- Exercised valid and invalid confirmation-code service paths with an isolated model stub.
- Verified confirm and resend payloads through the web flow with a local mock API.
